### PR TITLE
prefer babel-style module configs

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,12 +34,7 @@ module.exports = {
   },
   modules: [
     '@nuxtjs/workbox',
-    {
-      src: '@nuxtjs/google-analytics',
-      options: {
-        ua: gustavoConfig.googleAnalyticsId
-      }
-    }
+    ['@nuxtjs/google-analytics', { ua: gustavoConfig.googleAnalyticsId }]
   ],
   plugins: [
     // '~plugins/vue-hljs',


### PR DESCRIPTION
Hi! Recently we have upgraded module [docs](https://github.com/nuxt/modules/tree/master/modules/google-analytics) to a more simpler approach providing options (babel style arrays) So it would be nice to adopt new convention.